### PR TITLE
Add separate benchmark for utilities

### DIFF
--- a/src/Data/Vector/Hashtables/Internal.hs
+++ b/src/Data/Vector/Hashtables/Internal.hs
@@ -536,9 +536,10 @@ union
   -> m (Dictionary (PrimState m) ks k vs v)
 union = unionWith const
 
+{-# INLINE union #-}
+
 -- | The union of two maps.
--- If a key occurs in both maps,
--- the provided function (first argument) will be used to compute the result.
+-- The provided function (first argument) will be used to compute the result.
 unionWith
   :: (MVector ks k, MVector ks k, MVector vs v, PrimMonad m, Hashable k, Eq k)
   => (v -> v -> v)
@@ -546,6 +547,8 @@ unionWith
   -> Dictionary (PrimState m) ks k vs v
   -> m (Dictionary (PrimState m) ks k vs v)
 unionWith f = unionWithKey (const f)
+
+{-# INLINE unionWith #-}
 
 -- | The union of two maps.
 -- If a key occurs in both maps,
@@ -592,6 +595,8 @@ unionWithKey f t1 t2 = do
   mapM_ go indices
   return ht
 
+{-# INLINE unionWithKey #-}
+
 -- * Difference and intersection
 
 -- | Difference of two tables. Return elements of the first table
@@ -612,7 +617,7 @@ difference a b = do
       case mv of
         Nothing -> insert ht k v
         _       -> return ()
-{-# INLINABLE difference #-}
+{-# INLINE difference #-}
 
 -- | Difference with a combining function. When two equal keys are
 -- encountered, the combining function is applied to the values of these keys.
@@ -635,7 +640,7 @@ differenceWith f a b = do
       case mv of
         Nothing -> insert ht k v
         Just w  -> maybe (return ()) (insert ht k) (f v w)
-{-# INLINABLE differenceWith #-}
+{-# INLINE differenceWith #-}
 
 -- | Intersection of two maps. Return elements of the first
 -- map for keys existing in the second.
@@ -655,7 +660,7 @@ intersection a b = do
       case mv of
         Nothing -> return ()
         Just _  -> insert ht k v
-{-# INLINABLE intersection #-}
+{-# INLINE intersection #-}
 
 -- | Intersection of two maps. If a key occurs in both maps
 -- the provided function is used to combine the values from the two
@@ -677,7 +682,7 @@ intersectionWith f a b = do
       case mv of
         Nothing -> return ()
         Just w  -> insert ht k (f v w)
-{-# INLINABLE intersectionWith #-}
+{-# INLINE intersectionWith #-}
 
 -- | Intersection of two maps. If a key occurs in both maps
 -- the provided function is used to combine the values from the two
@@ -699,7 +704,7 @@ intersectionWithKey f a b = do
       case mv of
         Nothing -> return ()
         Just w  -> insert ht k (f k v w)
-{-# INLINABLE intersectionWithKey #-}
+{-# INLINE intersectionWithKey #-}
 
 -- * List conversions
 
@@ -710,6 +715,8 @@ fromList kv = do
     ht <- initialize 1
     mapM_ (uncurry (insert ht)) kv
     return ht
+
+{-# INLINE fromList #-}
 
 toList
   :: (MVector ks k, MVector vs v, PrimMonad m, Hashable k, Eq k)
@@ -726,6 +733,8 @@ toList DRef {..} = do
           v <- value !~ i
           return (k, v)
     mapM go indeces
+
+{-# INLINE toList #-}
 
 -- * Extras
 


### PR DESCRIPTION
<details>
    <summary>Separate benchmark for utilities added:</summary>

      benchmarking Utilities/1000/at'
      time                 16.61 μs   (16.46 μs .. 16.83 μs)
                           0.996 R²   (0.987 R² .. 1.000 R²)
      mean                 17.24 μs   (16.68 μs .. 19.27 μs)
      std dev              2.982 μs   (754.4 ns .. 6.493 μs)
      variance introduced by outliers: 95% (severely inflated)
      
      benchmarking Utilities/1000/insert
      time                 17.22 μs   (17.10 μs .. 17.41 μs)
                           0.999 R²   (0.999 R² .. 1.000 R²)
      mean                 17.28 μs   (17.17 μs .. 17.42 μs)
      std dev              407.0 ns   (300.5 ns .. 542.4 ns)
      variance introduced by outliers: 24% (moderately inflated)
      
      benchmarking Utilities/1000/delete
      time                 13.15 μs   (13.05 μs .. 13.30 μs)
                           0.995 R²   (0.988 R² .. 0.999 R²)
      mean                 13.76 μs   (13.41 μs .. 14.53 μs)
      std dev              1.654 μs   (828.3 ns .. 2.727 μs)
      variance introduced by outliers: 90% (severely inflated)
      
      benchmarking Utilities/1000/lookup
      time                 16.83 μs   (16.69 μs .. 16.98 μs)
                           0.999 R²   (0.999 R² .. 1.000 R²)
      mean                 16.64 μs   (16.56 μs .. 16.74 μs)
      std dev              310.1 ns   (235.0 ns .. 431.4 ns)
      variance introduced by outliers: 17% (moderately inflated)
      
      benchmarking Utilities/1000/lookup'
      time                 16.35 μs   (16.06 μs .. 16.64 μs)
                           0.998 R²   (0.997 R² .. 0.999 R²)
      mean                 16.06 μs   (15.87 μs .. 16.29 μs)
      std dev              737.2 ns   (603.8 ns .. 915.6 ns)
      variance introduced by outliers: 54% (severely inflated)
      
      benchmarking Utilities/1000/lookupIndex
      time                 18.69 μs   (18.39 μs .. 19.00 μs)
                           0.998 R²   (0.998 R² .. 0.999 R²)
      mean                 18.54 μs   (18.32 μs .. 18.76 μs)
      std dev              733.1 ns   (622.4 ns .. 904.0 ns)
      variance introduced by outliers: 47% (moderately inflated)
      
      benchmarking Utilities/1000/null
      time                 11.26 ns   (11.09 ns .. 11.41 ns)
                           0.999 R²   (0.998 R² .. 0.999 R²)
      mean                 11.18 ns   (11.07 ns .. 11.33 ns)
      std dev              423.8 ps   (364.0 ps .. 507.9 ps)
      variance introduced by outliers: 62% (severely inflated)
      
      benchmarking Utilities/1000/length
      time                 8.164 ns   (7.638 ns .. 8.705 ns)
                           0.982 R²   (0.974 R² .. 0.998 R²)
      mean                 8.078 ns   (7.872 ns .. 8.410 ns)
      std dev              872.0 ps   (608.5 ps .. 1.132 ns)
      variance introduced by outliers: 93% (severely inflated)
      
      benchmarking Utilities/1000/size
      time                 7.963 ns   (7.655 ns .. 8.310 ns)
                           0.992 R²   (0.986 R² .. 0.999 R²)
      mean                 8.051 ns   (7.812 ns .. 8.776 ns)
      std dev              1.177 ns   (545.2 ps .. 2.499 ns)
      variance introduced by outliers: 96% (severely inflated)
      
      benchmarking Utilities/1000/member
      time                 17.87 μs   (17.69 μs .. 18.29 μs)
                           0.992 R²   (0.976 R² .. 0.999 R²)
      mean                 18.51 μs   (18.08 μs .. 19.49 μs)
      std dev              2.119 μs   (857.5 ns .. 4.700 μs)
      variance introduced by outliers: 88% (severely inflated)
      
      benchmarking Utilities/1000/findWithDefault
      time                 16.51 μs   (16.46 μs .. 16.55 μs)
                           1.000 R²   (1.000 R² .. 1.000 R²)
      mean                 16.55 μs   (16.51 μs .. 16.60 μs)
      std dev              150.9 ns   (106.6 ns .. 214.6 ns)
      
      benchmarking Utilities/1000/alter
      time                 40.56 μs   (39.88 μs .. 41.76 μs)
                           0.994 R²   (0.986 R² .. 0.999 R²)
      mean                 40.76 μs   (40.20 μs .. 41.88 μs)
      std dev              2.606 μs   (1.403 μs .. 4.869 μs)
      variance introduced by outliers: 68% (severely inflated)
      
      benchmarking Utilities/1000/alterM
      time                 41.31 μs   (40.16 μs .. 42.82 μs)
                           0.994 R²   (0.989 R² .. 0.999 R²)
      mean                 40.66 μs   (40.16 μs .. 41.53 μs)
      std dev              2.052 μs   (1.195 μs .. 3.453 μs)
      variance introduced by outliers: 56% (severely inflated)
      
      benchmarking Utilities/1000/union
      time                 75.92 μs   (72.42 μs .. 82.03 μs)
                           0.978 R²   (0.950 R² .. 0.999 R²)
      mean                 74.11 μs   (72.83 μs .. 77.84 μs)
      std dev              6.602 μs   (2.428 μs .. 13.11 μs)
      variance introduced by outliers: 79% (severely inflated)
      
      benchmarking Utilities/1000/difference
      time                 58.82 μs   (56.54 μs .. 62.23 μs)
                           0.987 R²   (0.972 R² .. 0.999 R²)
      mean                 57.92 μs   (56.96 μs .. 59.97 μs)
      std dev              4.957 μs   (2.268 μs .. 8.292 μs)
      variance introduced by outliers: 78% (severely inflated)
      
      benchmarking Utilities/1000/intersection
      time                 97.41 μs   (94.25 μs .. 100.6 μs)
                           0.996 R²   (0.992 R² .. 1.000 R²)
      mean                 94.38 μs   (93.63 μs .. 96.16 μs)
      std dev              3.414 μs   (1.748 μs .. 6.452 μs)
      variance introduced by outliers: 36% (moderately inflated)
      
      benchmarking Utilities/1000/fromList
      time                 50.89 μs   (48.36 μs .. 54.25 μs)
                           0.980 R²   (0.967 R² .. 0.996 R²)
      mean                 53.48 μs   (50.00 μs .. 61.85 μs)
      std dev              17.73 μs   (9.772 μs .. 28.79 μs)
      variance introduced by outliers: 98% (severely inflated)
      
      benchmarking Utilities/1000/toList
      time                 39.82 μs   (39.43 μs .. 40.44 μs)
                           0.999 R²   (0.998 R² .. 1.000 R²)
      mean                 39.78 μs   (39.61 μs .. 40.10 μs)
      std dev              742.5 ns   (372.2 ns .. 1.255 μs)
      variance introduced by outliers: 15% (moderately inflated)
      
      benchmarking Utilities/10000/at'
      time                 166.3 μs   (164.5 μs .. 168.8 μs)
                           0.999 R²   (0.998 R² .. 1.000 R²)
      mean                 165.2 μs   (164.5 μs .. 166.8 μs)
      std dev              3.361 μs   (1.172 μs .. 5.626 μs)
      variance introduced by outliers: 14% (moderately inflated)
      
      benchmarking Utilities/10000/insert
      time                 184.1 μs   (175.8 μs .. 195.6 μs)
                           0.985 R²   (0.974 R² .. 0.999 R²)
      mean                 176.7 μs   (173.5 μs .. 183.4 μs)
      std dev              14.84 μs   (7.753 μs .. 22.70 μs)
      variance introduced by outliers: 74% (severely inflated)
      
      benchmarking Utilities/10000/delete
      time                 134.7 μs   (131.3 μs .. 138.2 μs)
                           0.997 R²   (0.993 R² .. 0.999 R²)
      mean                 131.0 μs   (130.0 μs .. 133.0 μs)
      std dev              4.781 μs   (2.948 μs .. 8.058 μs)
      variance introduced by outliers: 35% (moderately inflated)
      
      benchmarking Utilities/10000/lookup
      time                 168.2 μs   (165.7 μs .. 172.2 μs)
                           0.997 R²   (0.994 R² .. 1.000 R²)
      mean                 170.2 μs   (169.1 μs .. 172.9 μs)
      std dev              5.179 μs   (2.936 μs .. 9.936 μs)
      variance introduced by outliers: 26% (moderately inflated)
      
      benchmarking Utilities/10000/lookup'
      time                 164.2 μs   (158.0 μs .. 173.9 μs)
                           0.988 R²   (0.974 R² .. 0.999 R²)
      mean                 162.1 μs   (159.8 μs .. 167.2 μs)
      std dev              10.86 μs   (6.037 μs .. 20.81 μs)
      variance introduced by outliers: 64% (severely inflated)
      
      benchmarking Utilities/10000/lookupIndex
      time                 184.0 μs   (177.1 μs .. 191.1 μs)
                           0.994 R²   (0.989 R² .. 0.999 R²)
      mean                 176.8 μs   (175.2 μs .. 180.1 μs)
      std dev              7.727 μs   (4.206 μs .. 13.09 μs)
      variance introduced by outliers: 42% (moderately inflated)
      
      benchmarking Utilities/10000/null
      time                 12.04 ns   (11.40 ns .. 12.98 ns)
                           0.967 R²   (0.933 R² .. 0.997 R²)
      mean                 12.42 ns   (11.93 ns .. 13.21 ns)
      std dev              2.053 ns   (1.307 ns .. 3.498 ns)
      variance introduced by outliers: 97% (severely inflated)
      
      benchmarking Utilities/10000/length
      time                 8.103 ns   (8.005 ns .. 8.278 ns)
                           0.998 R²   (0.996 R² .. 0.999 R²)
      mean                 8.410 ns   (8.284 ns .. 8.565 ns)
      std dev              481.5 ps   (400.2 ps .. 594.7 ps)
      variance introduced by outliers: 79% (severely inflated)
      
      benchmarking Utilities/10000/size
      time                 8.261 ns   (7.812 ns .. 8.989 ns)
                           0.959 R²   (0.905 R² .. 0.995 R²)
      mean                 8.477 ns   (8.158 ns .. 9.374 ns)
      std dev              1.640 ns   (769.0 ps .. 3.138 ns)
      variance introduced by outliers: 98% (severely inflated)
      
      benchmarking Utilities/10000/member
      time                 206.8 μs   (185.0 μs .. 235.2 μs)
                           0.935 R²   (0.888 R² .. 0.998 R²)
      mean                 189.7 μs   (184.6 μs .. 204.2 μs)
      std dev              26.39 μs   (8.909 μs .. 53.02 μs)
      variance introduced by outliers: 89% (severely inflated)
      
      benchmarking Utilities/10000/findWithDefault
      time                 169.6 μs   (166.9 μs .. 172.4 μs)
                           0.998 R²   (0.996 R² .. 0.999 R²)
      mean                 172.0 μs   (170.3 μs .. 174.6 μs)
      std dev              7.202 μs   (5.185 μs .. 11.20 μs)
      variance introduced by outliers: 41% (moderately inflated)
      
      benchmarking Utilities/10000/alter
      time                 439.9 μs   (425.6 μs .. 463.9 μs)
                           0.972 R²   (0.941 R² .. 0.995 R²)
      mean                 448.7 μs   (433.5 μs .. 485.7 μs)
      std dev              69.29 μs   (35.64 μs .. 125.2 μs)
      variance introduced by outliers: 89% (severely inflated)
      
      benchmarking Utilities/10000/alterM
      time                 434.6 μs   (414.1 μs .. 450.0 μs)
                           0.988 R²   (0.980 R² .. 0.994 R²)
      mean                 424.5 μs   (406.3 μs .. 488.7 μs)
      std dev              104.2 μs   (22.51 μs .. 217.4 μs)
      variance introduced by outliers: 96% (severely inflated)
      
      benchmarking Utilities/10000/union
      time                 930.2 μs   (795.1 μs .. 1.097 ms)
                           0.856 R²   (0.806 R² .. 0.923 R²)
      mean                 1.049 ms   (980.2 μs .. 1.140 ms)
      std dev              289.7 μs   (242.3 μs .. 362.5 μs)
      variance introduced by outliers: 96% (severely inflated)
      
      benchmarking Utilities/10000/difference
      time                 922.3 μs   (883.3 μs .. 970.6 μs)
                           0.983 R²   (0.963 R² .. 0.996 R²)
      mean                 907.0 μs   (890.3 μs .. 935.9 μs)
      std dev              72.01 μs   (43.89 μs .. 138.2 μs)
      variance introduced by outliers: 64% (severely inflated)
      
      benchmarking Utilities/10000/intersection
      time                 1.327 ms   (1.268 ms .. 1.404 ms)
                           0.983 R²   (0.975 R² .. 0.992 R²)
      mean                 1.369 ms   (1.336 ms .. 1.423 ms)
      std dev              141.0 μs   (101.9 μs .. 225.2 μs)
      variance introduced by outliers: 73% (severely inflated)
      
      benchmarking Utilities/10000/fromList
      time                 476.6 μs   (458.4 μs .. 494.1 μs)
                           0.992 R²   (0.989 R² .. 0.997 R²)
      mean                 472.9 μs   (468.8 μs .. 481.5 μs)
      std dev              18.67 μs   (11.55 μs .. 28.14 μs)
      variance introduced by outliers: 33% (moderately inflated)
      
      benchmarking Utilities/10000/toList
      time                 822.0 μs   (759.9 μs .. 890.3 μs)
                           0.966 R²   (0.954 R² .. 0.984 R²)
      mean                 779.9 μs   (754.9 μs .. 817.8 μs)
      std dev              93.44 μs   (66.97 μs .. 120.6 μs)
      variance introduced by outliers: 80% (severely inflated)
      
      benchmarking Utilities/100000/at'
      time                 1.832 ms   (1.754 ms .. 1.930 ms)
                           0.986 R²   (0.978 R² .. 0.996 R²)
      mean                 1.755 ms   (1.727 ms .. 1.802 ms)
      std dev              119.6 μs   (80.73 μs .. 171.0 μs)
      variance introduced by outliers: 52% (severely inflated)
      
      benchmarking Utilities/100000/insert
      time                 1.923 ms   (1.862 ms .. 2.013 ms)
                           0.991 R²   (0.981 R² .. 0.998 R²)
      mean                 1.882 ms   (1.854 ms .. 1.921 ms)
      std dev              113.4 μs   (81.41 μs .. 172.8 μs)
      variance introduced by outliers: 45% (moderately inflated)
      
      benchmarking Utilities/100000/delete
      time                 1.315 ms   (1.283 ms .. 1.368 ms)
                           0.992 R²   (0.989 R² .. 0.996 R²)
      mean                 1.363 ms   (1.343 ms .. 1.387 ms)
      std dev              73.51 μs   (62.59 μs .. 87.46 μs)
      variance introduced by outliers: 42% (moderately inflated)
      
      benchmarking Utilities/100000/lookup
      time                 1.831 ms   (1.696 ms .. 2.045 ms)
                           0.953 R²   (0.908 R² .. 0.998 R²)
      mean                 1.728 ms   (1.697 ms .. 1.830 ms)
      std dev              172.6 μs   (55.89 μs .. 350.8 μs)
      variance introduced by outliers: 70% (severely inflated)
      
      benchmarking Utilities/100000/lookup'
      time                 1.914 ms   (1.735 ms .. 2.089 ms)
                           0.964 R²   (0.947 R² .. 0.991 R²)
      mean                 1.707 ms   (1.664 ms .. 1.790 ms)
      std dev              185.9 μs   (118.6 μs .. 282.8 μs)
      variance introduced by outliers: 74% (severely inflated)
      
      benchmarking Utilities/100000/lookupIndex
      time                 1.923 ms   (1.804 ms .. 2.091 ms)
                           0.975 R²   (0.955 R² .. 0.997 R²)
      mean                 1.875 ms   (1.847 ms .. 1.932 ms)
      std dev              131.7 μs   (82.92 μs .. 228.7 μs)
      variance introduced by outliers: 52% (severely inflated)
      
      benchmarking Utilities/100000/null
      time                 12.10 ns   (11.28 ns .. 13.01 ns)
                           0.970 R²   (0.943 R² .. 0.997 R²)
      mean                 11.98 ns   (11.52 ns .. 13.38 ns)
      std dev              2.429 ns   (994.3 ps .. 4.677 ns)
      variance introduced by outliers: 98% (severely inflated)
      
      benchmarking Utilities/100000/length
      time                 8.447 ns   (8.306 ns .. 8.590 ns)
                           0.996 R²   (0.994 R² .. 0.998 R²)
      mean                 8.556 ns   (8.415 ns .. 8.702 ns)
      std dev              513.2 ps   (417.7 ps .. 606.6 ps)
      variance introduced by outliers: 81% (severely inflated)
      
      benchmarking Utilities/100000/size
      time                 8.290 ns   (8.084 ns .. 8.542 ns)
                           0.994 R²   (0.990 R² .. 0.997 R²)
      mean                 8.160 ns   (8.006 ns .. 8.393 ns)
      std dev              575.9 ps   (414.7 ps .. 839.6 ps)
      variance introduced by outliers: 85% (severely inflated)
      
      benchmarking Utilities/100000/member
      time                 1.878 ms   (1.830 ms .. 1.937 ms)
                           0.995 R²   (0.993 R² .. 0.998 R²)
      mean                 1.876 ms   (1.858 ms .. 1.902 ms)
      std dev              75.91 μs   (62.57 μs .. 94.12 μs)
      variance introduced by outliers: 26% (moderately inflated)
      
      benchmarking Utilities/100000/findWithDefault
      time                 1.835 ms   (1.757 ms .. 1.914 ms)
                           0.993 R²   (0.989 R² .. 0.998 R²)
      mean                 1.784 ms   (1.763 ms .. 1.809 ms)
      std dev              78.63 μs   (63.06 μs .. 108.9 μs)
      variance introduced by outliers: 31% (moderately inflated)
      
      benchmarking Utilities/100000/alter
      time                 4.001 ms   (3.903 ms .. 4.066 ms)
                           0.985 R²   (0.964 R² .. 0.997 R²)
      mean                 4.344 ms   (4.215 ms .. 4.573 ms)
      std dev              520.0 μs   (317.1 μs .. 711.8 μs)
      variance introduced by outliers: 71% (severely inflated)
      
      benchmarking Utilities/100000/alterM
      time                 4.452 ms   (4.188 ms .. 4.838 ms)
                           0.960 R²   (0.937 R² .. 0.982 R²)
      mean                 4.806 ms   (4.631 ms .. 5.023 ms)
      std dev              628.7 μs   (514.2 μs .. 818.2 μs)
      variance introduced by outliers: 74% (severely inflated)
      
      benchmarking Utilities/100000/union
      time                 10.28 ms   (6.974 ms .. 13.11 ms)
                           0.734 R²   (0.498 R² .. 0.899 R²)
      mean                 13.01 ms   (10.53 ms .. 22.30 ms)
      std dev              11.83 ms   (2.142 ms .. 24.14 ms)
      variance introduced by outliers: 96% (severely inflated)
      
      benchmarking Utilities/100000/difference
      time                 19.31 ms   (14.87 ms .. 25.14 ms)
                           0.612 R²   (0.351 R² .. 0.943 R²)
      mean                 20.33 ms   (17.85 ms .. 24.74 ms)
      std dev              7.860 ms   (3.952 ms .. 11.66 ms)
      variance introduced by outliers: 95% (severely inflated)
      
      benchmarking Utilities/100000/intersection
      time                 24.20 ms   (22.90 ms .. 25.31 ms)
                           0.975 R²   (0.938 R² .. 0.992 R²)
      mean                 22.85 ms   (21.95 ms .. 24.23 ms)
      std dev              2.384 ms   (1.755 ms .. 3.746 ms)
      variance introduced by outliers: 46% (moderately inflated)
      
      benchmarking Utilities/100000/fromList
      time                 6.021 ms   (5.197 ms .. 6.882 ms)
                           0.814 R²   (0.683 R² .. 0.919 R²)
      mean                 7.719 ms   (6.911 ms .. 8.828 ms)
      std dev              2.732 ms   (1.938 ms .. 4.183 ms)
      variance introduced by outliers: 97% (severely inflated)
      
      benchmarking Utilities/100000/toList
      time                 15.18 ms   (14.11 ms .. 16.32 ms)
                           0.975 R²   (0.956 R² .. 0.992 R²)
      mean                 14.08 ms   (13.71 ms .. 14.70 ms)
      std dev              1.158 ms   (748.5 μs .. 1.683 ms)
      variance introduced by outliers: 39% (moderately inflated)
      
      benchmarking Utilities/1000000/at'
      time                 17.23 ms   (17.05 ms .. 17.41 ms)
                           0.999 R²   (0.999 R² .. 1.000 R²)
      mean                 17.29 ms   (17.21 ms .. 17.40 ms)
      std dev              223.6 μs   (180.9 μs .. 282.8 μs)
      
      benchmarking Utilities/1000000/insert
      time                 17.13 ms   (16.19 ms .. 17.80 ms)
                           0.983 R²   (0.963 R² .. 0.996 R²)
      mean                 19.46 ms   (18.60 ms .. 21.29 ms)
      std dev              2.888 ms   (1.508 ms .. 5.111 ms)
      variance introduced by outliers: 67% (severely inflated)
      
      benchmarking Utilities/1000000/delete
      time                 13.84 ms   (13.43 ms .. 14.25 ms)
                           0.992 R²   (0.985 R² .. 0.997 R²)
      mean                 13.32 ms   (13.08 ms .. 13.61 ms)
      std dev              687.9 μs   (546.4 μs .. 898.5 μs)
      variance introduced by outliers: 22% (moderately inflated)
      
      benchmarking Utilities/1000000/lookup
      time                 17.72 ms   (17.36 ms .. 18.06 ms)
                           0.997 R²   (0.994 R² .. 0.999 R²)
      mean                 18.17 ms   (17.95 ms .. 18.44 ms)
      std dev              581.2 μs   (470.5 μs .. 788.8 μs)
      
      benchmarking Utilities/1000000/lookup'
      time                 17.19 ms   (16.39 ms .. 18.60 ms)
                           0.975 R²   (0.950 R² .. 0.996 R²)
      mean                 16.95 ms   (16.52 ms .. 17.65 ms)
      std dev              1.271 ms   (785.3 μs .. 1.835 ms)
      variance introduced by outliers: 33% (moderately inflated)
      
      benchmarking Utilities/1000000/lookupIndex
      time                 27.09 ms   (20.56 ms .. 33.91 ms)
                           0.858 R²   (0.787 R² .. 0.977 R²)
      mean                 20.45 ms   (19.03 ms .. 24.03 ms)
      std dev              4.543 ms   (2.033 ms .. 8.032 ms)
      variance introduced by outliers: 79% (severely inflated)
      
      benchmarking Utilities/1000000/null
      time                 12.68 ns   (12.48 ns .. 12.85 ns)
                           0.998 R²   (0.997 R² .. 0.999 R²)
      mean                 12.55 ns   (12.37 ns .. 12.85 ns)
      std dev              818.1 ps   (565.6 ps .. 1.411 ns)
      variance introduced by outliers: 83% (severely inflated)
      
      benchmarking Utilities/1000000/length
      time                 7.605 ns   (7.583 ns .. 7.637 ns)
                           1.000 R²   (1.000 R² .. 1.000 R²)
      mean                 7.715 ns   (7.658 ns .. 7.810 ns)
      std dev              243.0 ps   (179.3 ps .. 360.9 ps)
      variance introduced by outliers: 53% (severely inflated)
      
      benchmarking Utilities/1000000/size
      time                 7.557 ns   (7.545 ns .. 7.579 ns)
                           1.000 R²   (1.000 R² .. 1.000 R²)
      mean                 7.581 ns   (7.562 ns .. 7.618 ns)
      std dev              84.81 ps   (49.57 ps .. 131.3 ps)
      variance introduced by outliers: 12% (moderately inflated)
      
      benchmarking Utilities/1000000/member
      time                 18.15 ms   (17.92 ms .. 18.39 ms)
                           0.999 R²   (0.999 R² .. 1.000 R²)
      mean                 18.07 ms   (18.00 ms .. 18.16 ms)
      std dev              200.9 μs   (144.5 μs .. 255.7 μs)
      
      benchmarking Utilities/1000000/findWithDefault
      time                 16.94 ms   (16.63 ms .. 17.31 ms)
                           0.998 R²   (0.996 R² .. 0.999 R²)
      mean                 16.59 ms   (16.46 ms .. 16.75 ms)
      std dev              367.3 μs   (285.7 μs .. 448.9 μs)
      
      benchmarking Utilities/1000000/alter
      time                 42.01 ms   (39.04 ms .. 46.31 ms)
                           0.969 R²   (0.917 R² .. 0.996 R²)
      mean                 45.99 ms   (43.95 ms .. 49.48 ms)
      std dev              4.878 ms   (2.410 ms .. 7.626 ms)
      variance introduced by outliers: 41% (moderately inflated)
      
      benchmarking Utilities/1000000/alterM
      time                 43.66 ms   (42.75 ms .. 44.89 ms)
                           0.998 R²   (0.995 R² .. 0.999 R²)
      mean                 43.70 ms   (43.14 ms .. 44.25 ms)
      std dev              1.143 ms   (869.9 μs .. 1.448 ms)
      
      benchmarking Utilities/1000000/union
      time                 88.93 ms   (86.58 ms .. 92.72 ms)
                           0.998 R²   (0.993 R² .. 1.000 R²)
      mean                 90.51 ms   (89.24 ms .. 91.94 ms)
      std dev              2.215 ms   (1.850 ms .. 2.859 ms)
      
      benchmarking Utilities/1000000/difference
      time                 196.3 ms   (175.4 ms .. 218.4 ms)
                           0.988 R²   (0.954 R² .. 1.000 R²)
      mean                 191.7 ms   (181.3 ms .. 198.2 ms)
      std dev              11.22 ms   (6.837 ms .. 15.56 ms)
      variance introduced by outliers: 15% (moderately inflated)
      
      benchmarking Utilities/1000000/intersection
      time                 254.7 ms   (226.0 ms .. 272.2 ms)
                           0.997 R²   (0.992 R² .. 1.000 R²)
      mean                 250.2 ms   (237.8 ms .. 259.2 ms)
      std dev              13.55 ms   (5.588 ms .. 19.79 ms)
      variance introduced by outliers: 16% (moderately inflated)
      
      benchmarking Utilities/1000000/fromList
      time                 98.77 ms   (80.96 ms .. 114.5 ms)
                           0.955 R²   (0.899 R² .. 0.995 R²)
      mean                 91.41 ms   (79.61 ms .. 100.2 ms)
      std dev              15.71 ms   (9.389 ms .. 22.97 ms)
      variance introduced by outliers: 54% (severely inflated)
      
      benchmarking Utilities/1000000/toList
      time                 179.7 ms   (168.9 ms .. 192.5 ms)
                           0.997 R²   (0.986 R² .. 1.000 R²)
      mean                 171.5 ms   (163.3 ms .. 177.4 ms)
      std dev              10.06 ms   (6.555 ms .. 14.03 ms)
      variance introduced by outliers: 15% (moderately inflated)

</details>