### PR TITLE
vector-hashtables.cabal: put lower bound on 'primitive' for Debian stable

### DIFF
--- a/vector-hashtables.cabal
+++ b/vector-hashtables.cabal
@@ -30,7 +30,7 @@ library
                        Data.Primitive.PrimArray.Utils
   ghc-options:         -O2
   build-depends:       base >= 4.7 && < 5
-                     , primitive
+                     , primitive >= 0.7.1.0
                      , vector
                      , hashable
   default-language:    Haskell2010


### PR DESCRIPTION
Debian Stable (11 "Bullseye") ships a package `libghc-primitive-dev` which supplies `primitive` at version 0.7.0.1 which doesn't include the `clone*` functions.