### PR TITLE
bump hspec to <2.12

### DIFF
--- a/vector-hashtables.cabal
+++ b/vector-hashtables.cabal
@@ -72,12 +72,12 @@ test-suite vector-hashtables-test
 
   -- Additional dependencies
   build-depends:
-      hspec                >= 2.6.0    && < 2.11
+      hspec                >= 2.6.0    && < 2.12
     , QuickCheck           >= 2.12.6.1 && < 2.15
     , quickcheck-instances >= 0.3.19   && < 0.4
 
   build-tool-depends:
-    hspec-discover:hspec-discover >= 2.6.0 && < 2.11
+    hspec-discover:hspec-discover >= 2.6.0 && < 2.12
 
 source-repository head
   type:     git


### PR DESCRIPTION
Thanks for the reminder to the friendly stack folks: https://github.com/commercialhaskell/stackage/issues/6952

I want to do a minor release on Hackage rather than a revision with this commit because of the couple of  .cabal file cleanups earlier.