### PR TITLE
Add wasm32 support

### DIFF
--- a/vector-hashtables.cabal
+++ b/vector-hashtables.cabal
@@ -27,7 +27,7 @@ tested-with:
     GHC == 8.6.5
 
 library
-  if arch(i386)
+  if arch(i386) || arch(wasm32)
     hs-source-dirs:    src, src-i386
   else
     hs-source-dirs:    src, src-gen


### PR DESCRIPTION
In my attempt to port Agda to WebAssembly via [the official WASM backend](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/wasm.html), I notice that the hash table always hangs or makes illegal memory access. Upon further investigation, it turns out that there is actually a warning during compiling:

```
src-gen/Data/Vector/Hashtables/Internal/Mask.hs:10:8: warning: [GHC-97441] [-Woverflowed-literals]
    Literal 9223372036854775807 is out of the Int range -2147483648..2147483647
   |
10 | mask = 0x7FFFFFFFFFFFFFFF :: Int
   |        ^^^^^^^^^^^^^^^^^^
```

Since wasm32 has only 32-bit address space, selecting the 64-bit mask constant apparently causes some undefined behavior. This patch adds an extra condition for wasm32 to use the 32-bit mask. 
