### PR TITLE
More bangs

### DIFF
--- a/src/Data/Vector/Hashtables/Internal.hs
+++ b/src/Data/Vector/Hashtables/Internal.hs
@@ -70,9 +70,9 @@ data Dictionary_ s ks k vs v = Dictionary {
     hashCode,
     next,
     buckets,
-    refs :: IntArray s,
-    key :: ks s k,
-    value :: vs s v
+    refs :: !(IntArray s),
+    key :: !(ks s k),
+    value :: !(vs s v)
 }
 
 getCount, getFreeList, getFreeCount :: Int
@@ -85,10 +85,10 @@ getFreeCount = 2
 data FrozenDictionary ks k vs v = FrozenDictionary {
     fhashCode,
     fnext,
-    fbuckets :: A.PrimArray Int,
-    count, freeList, freeCount :: Int,
-    fkey :: ks k,
-    fvalue :: vs v
+    fbuckets :: !(A.PrimArray Int),
+    count, freeList, freeCount :: !Int,
+    fkey :: !(ks k),
+    fvalue :: !(vs v)
 } deriving (Eq, Ord, Show)
 
 -- | /O(1)/ in the best case, /O(n)/ in the worst case.

--- a/src/Data/Vector/Hashtables/Internal.hs
+++ b/src/Data/Vector/Hashtables/Internal.hs
@@ -106,15 +106,20 @@ findElem FrozenDictionary{..} key' = go $ fbuckets !. (hashCode' `rem` A.sizeofP
 
 -- | Infix version of @unsafeRead@.
 (!~) :: (MVector v a, PrimMonad m) => v (PrimState m) a -> Int -> m a
-(!~) = V.unsafeRead
+(!~) xs !i = V.unsafeRead xs i
+-- Why do we need ! before i?
+-- The reason is that V.unsafeRead is essentially V.basicUnsafeRead,
+-- which is an opaque class member and, unless V.unsafeRead was
+-- already specialised to a specific v, GHC has no clue that i is most certainly
+-- to be used eagerly. Bang before i hints this vital for optimizer information.
 
 -- | Infix version of @unsafeIndex@.
 (!.~) :: (Vector v a) => v a -> Int -> a
-(!.~) = VI.unsafeIndex
+(!.~) xs !i = VI.unsafeIndex xs i
 
 -- | Infix version of @unsafeWrite@.
 (<~~) :: (MVector v a, PrimMonad m) => v (PrimState m) a -> Int -> a -> m ()
-(<~~) = V.unsafeWrite
+(<~~) xs !i x = V.unsafeWrite xs i x
 
 -- | Infix version of @readPrimArray@.
 (!) :: PrimMonad m => A.MutablePrimArray (PrimState m) Int -> Int -> m Int


### PR DESCRIPTION
Up to 30% faster:
```
All
  Comparison
    1000000
      insert
        vector-hashtables boxed:        OK
          37.9 ms ± 975 μs,       same as baseline
        vector-hashtables unboxed keys: OK
          26.0 ms ± 243 μs,       same as baseline
        vector-hashtables:              OK
          6.42 ms ± 121 μs, 26% less than baseline
      insert (resize)
        vector-hashtables boxed:        OK
          52.8 ms ± 849 μs,  3% less than baseline
        vector-hashtables unboxed keys: OK
          35.4 ms ± 657 μs,  4% less than baseline
        vector-hashtables:              OK
          11.2 ms ± 226 μs, 17% less than baseline
      insert, delete
        vector-hashtables:              OK
          10.6 ms ± 245 μs, 31% less than baseline
      find
        vector-hashtables:              OK
          4.40 ms ± 152 μs, 27% less than baseline
        vector-hashtables (frozen):     OK
          1.95 ns ±  56 ps,       same as baseline
      lookupIndex
        vector-hashtables:              OK
          2.73 ms ±  53 μs, 32% less than baseline
      fromList
        vector-hashtables:              OK
          16.4 ms ± 334 μs, 24% less than baseline
      toList
        vector-hashtables:              OK
          54.2 ms ± 2.0 ms,       same as baseline
```