### PR TITLE
vector-hashtables.cabal: bump QuickCheck bound

### DIFF
--- a/vector-hashtables.cabal
+++ b/vector-hashtables.cabal
@@ -71,7 +71,7 @@ test-suite vector-hashtables-test
   -- Additional dependencies
   build-depends:
       hspec                >= 2.6.0    && < 2.12
-    , QuickCheck           >= 2.12.6.1 && < 2.16
+    , QuickCheck           >= 2.12.6.1 && < 2.17
     , quickcheck-instances >= 0.3.19   && < 0.4
 
   build-tool-depends:


### PR DESCRIPTION
see https://github.com/commercialhaskell/stackage/issues/7778