### PR TITLE
update CI/tested-with for GHCs up to 9.12

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,19 +28,29 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.1
+          - compiler: ghc-9.12.2
             compilerKind: ghc
-            compilerVersion: 9.8.1
+            compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.3
+          - compiler: ghc-9.10.2
             compilerKind: ghc
-            compilerVersion: 9.6.3
+            compilerVersion: 9.10.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.7
+          - compiler: ghc-9.8.4
             compilerKind: ghc
-            compilerVersion: 9.4.7
+            compilerVersion: 9.8.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.6.7
+            compilerKind: ghc
+            compilerVersion: 9.6.7
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.4.8
+            compilerKind: ghc
+            compilerVersion: 9.4.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8

--- a/vector-hashtables.cabal
+++ b/vector-hashtables.cabal
@@ -18,14 +18,16 @@ extra-doc-files:     README.md,
                      changelog.md
 extra-source-files:  gen/GenPrimes.hs
 tested-with:
-    GHC == 9.8.1
-    GHC == 9.6.3
-    GHC == 9.4.7
-    GHC == 9.2.8
-    GHC == 9.0.2
-    GHC == 8.10.7
-    GHC == 8.8.4
-    GHC == 8.6.5
+  GHC == 9.12.2
+  GHC == 9.10.2
+  GHC == 9.8.4
+  GHC == 9.6.7
+  GHC == 9.4.8
+  GHC == 9.2.8
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
 
 library
   hs-source-dirs:    src


### PR DESCRIPTION
~~I wanted to switch to the set syntax in `tested-with`, which made me bump `cabal-version`, which made me update the name of the license. Let me know if that's too much: I could roll back to the old syntax...~~ just update GHCs, see discussion below